### PR TITLE
Filter detailed info

### DIFF
--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -25,7 +25,7 @@ import Dropdown from '../../common/dropdown';
 const { BOOL } = INPUT_CONSTANTS;
 
 const DropdownWide = styled(Dropdown)`
-max-width: 40rem;
+max-width: max-content;
 `;
 
 /* Filters info table
@@ -37,24 +37,21 @@ max-width: 40rem;
  */
 function FilterInfoTable (props) {
   const { filter_data } = props;
-  
   return (
     <table style={{"border": "1px solid", "margin": "auto"}}>
-      <thead>
-        <tr>
-          <td>
-            <b style={{"padding": "5px"}}>Filter Info</b>
-          </td>
-        </tr>
-      </thead>
       <tbody>
-          {filter_data.map( (info) => ( info.info ?
-            <tr key={info.info+"-label"}>
-              <td style={{"padding": "5px", "border": "1px solid"}}>{info.label}</td>
-              <td style={{"padding": "5px", "border": "1px solid"}}>{info.info}</td>
-            </tr>
-            : null
-          ) )}
+          <tr key={filter_data.filter_title+"-label"}>
+            <td style={{"padding": "5px", "border": "1px solid"}}>Filter title</td>
+            <td style={{"padding": "5px", "border": "1px solid"}}>{filter_data.filter_title}</td>
+          </tr>
+          <tr key={filter_data.filter_title+"-description"}>
+            <td style={{"padding": "5px", "border": "1px solid"}}>Filter description</td>
+            <td style={{"padding": "5px", "border": "1px solid"}}>{filter_data.filter_description}</td>
+          </tr>
+          <tr key={filter_data.filter_title+"-source_url"}>
+            <td style={{"padding": "5px", "border": "1px solid"}}>Data source</td>
+            <td style={{"padding": "5px", "border": "1px solid"}}><a href={filter_data.filter_source} target="_blank"> {filter_data.filter_source} </a></td>
+          </tr>
       </tbody>
     </table>
   );
@@ -201,16 +198,11 @@ function FiltersForm (props) {
                                           Info
                                         </Button>
                                       }>
-                                      <FilterInfoTable filter_data={[
-                                        {label: "Title: ", info: filter.title}, 
-                                        {label: "Description: ", info: filter.description}, 
-                                        {label: "Secondary description: ", info: filter.secondary_description},
-                                        {label: "Energy type: ", info: filter.energy_type.join( ", " )},
-                                        {label: "Unit: ", info: filter.unit},
-                                        {label: "Category: ", info: filter.category},
-                                        {label: "Secondary category: ", info: filter.secondary_category},
-                                        {label: "Layer: ", info: filter.layer},
-                                      ]}/>
+                                      <FilterInfoTable filter_data={{
+                                        filter_title: filter.title, 
+                                        filter_description: filter.description,
+                                        filter_source: filter.source_url, 
+                                      }}/>
                                     </DropdownWide>
                                   )}
 

--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -1,5 +1,7 @@
 import React, { useCallback } from 'react';
 import T from 'prop-types';
+import styled from 'styled-components';
+import Button from '../../../styles/button/button';
 
 import {
   FormWrapper,
@@ -14,13 +16,49 @@ import { Accordion, AccordionFold, AccordionFoldTrigger } from '../../../compone
 import Heading from '../../../styles/type/heading';
 import { makeTitleCase } from '../../../styles/utils/general';
 
-import InfoButton from '../../common/info-button';
 import { FormSwitch } from '../../../styles/form/switch';
 import { INPUT_CONSTANTS } from '../panel-data';
 
 import FormInput from './form-input';
+import Dropdown from '../../common/dropdown';
 
 const { BOOL } = INPUT_CONSTANTS;
+
+const DropdownWide = styled(Dropdown)`
+  max-width: 22rem;
+  max-width: max-content;
+`;
+
+/* Filters info table
+ * @param filter_data is an array of shape
+ *  [
+ *    {label: String, info: String},
+ *    ...
+ *  ]
+ */
+function FilterInfoTable (props) {
+  const { filter_data } = props;
+  
+  return (
+    <table>
+      <thead>
+          <b>Filter Info</b>
+      </thead>
+      <tbody>
+          {filter_data.map( (info) => (
+            <tr>
+              <td>{info.label}</td>
+              <td style={{"padding-left": "10px"}}>{info.info}</td>
+            </tr>
+          ) )}
+      </tbody>
+    </table>
+  );
+}
+
+FilterInfoTable.propTypes = {
+  filter_data: T.array,
+};
 
 /* Filters form
  * @param outputFilters is an array of shape
@@ -146,12 +184,28 @@ function FiltersForm (props) {
                                     )}
                                   </PanelOptionTitle>
                                   {filter.info && (
-                                    <InfoButton
-                                      info={filter.info}
-                                      id={filter.name}
-                                    >
-                                      Info
-                                    </InfoButton>
+                                    <DropdownWide id={filter.name} data-tip data-for={filter.name}
+                                      triggerElement={
+                                        <Button
+                                          hideText
+                                          useIcon='circle-information'
+                                          className='info-button'
+                                          title={filter.info}
+                                        >
+                                          Info
+                                        </Button>
+                                      }>
+                                      <FilterInfoTable filter_data={[
+                                        {label: "Title: ", info: filter.title}, 
+                                        {label: "Description: ", info: filter.description}, 
+                                        {label: "Secondary description: ", info: filter.secondary_description},
+                                        {label: "Energy type: ", info: filter.energy_type},
+                                        {label: "Unit: ", info: filter.unit},
+                                        {label: "Category: ", info: filter.category},
+                                        {label: "Secondary category: ", info: filter.secondary_category},
+                                        {label: "Layer: ", info: filter.layer},
+                                      ]}/>
+                                    </DropdownWide>
                                   )}
 
                                   {filter.input.type === BOOL && (

--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -26,6 +26,8 @@ const { BOOL } = INPUT_CONSTANTS;
 
 const DropdownWide = styled(Dropdown)`
 max-width: max-content;
+background: rgba(0,0,0,0.8);
+color: white;
 `;
 
 /* Filters info table

--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -25,8 +25,7 @@ import Dropdown from '../../common/dropdown';
 const { BOOL } = INPUT_CONSTANTS;
 
 const DropdownWide = styled(Dropdown)`
-  max-width: 22rem;
-  max-width: max-content;
+  max-width: 40rem;
 `;
 
 /* Filters info table
@@ -40,16 +39,17 @@ function FilterInfoTable (props) {
   const { filter_data } = props;
   
   return (
-    <table>
+    <table style={{"border": "1px solid"}}>
       <thead>
-          <b>Filter Info</b>
+          <b style={{"padding": "5px"}}>Filter Info</b>
       </thead>
       <tbody>
-          {filter_data.map( (info) => (
+          {filter_data.map( (info) => ( info.info ?
             <tr>
-              <td>{info.label}</td>
-              <td style={{"padding-left": "10px"}}>{info.info}</td>
+              <td style={{"padding": "5px", "border": "1px solid"}}>{info.label}</td>
+              <td style={{"padding": "5px", "border": "1px solid"}}>{info.info}</td>
             </tr>
+            : null
           ) )}
       </tbody>
     </table>
@@ -184,7 +184,9 @@ function FiltersForm (props) {
                                     )}
                                   </PanelOptionTitle>
                                   {filter.info && (
-                                    <DropdownWide id={filter.name} data-tip data-for={filter.name}
+                                    <DropdownWide
+                                      alignment='center'
+                                      direction='down'
                                       triggerElement={
                                         <Button
                                           hideText

--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -25,7 +25,7 @@ import Dropdown from '../../common/dropdown';
 const { BOOL } = INPUT_CONSTANTS;
 
 const DropdownWide = styled(Dropdown)`
-  max-width: 40rem;
+max-width: 40rem;
 `;
 
 /* Filters info table
@@ -39,13 +39,17 @@ function FilterInfoTable (props) {
   const { filter_data } = props;
   
   return (
-    <table style={{"border": "1px solid"}}>
+    <table style={{"border": "1px solid", "margin": "auto"}}>
       <thead>
-          <b style={{"padding": "5px"}}>Filter Info</b>
+        <tr>
+          <td>
+            <b style={{"padding": "5px"}}>Filter Info</b>
+          </td>
+        </tr>
       </thead>
       <tbody>
           {filter_data.map( (info) => ( info.info ?
-            <tr>
+            <tr key={info.info+"-label"}>
               <td style={{"padding": "5px", "border": "1px solid"}}>{info.label}</td>
               <td style={{"padding": "5px", "border": "1px solid"}}>{info.info}</td>
             </tr>
@@ -201,7 +205,7 @@ function FiltersForm (props) {
                                         {label: "Title: ", info: filter.title}, 
                                         {label: "Description: ", info: filter.description}, 
                                         {label: "Secondary description: ", info: filter.secondary_description},
-                                        {label: "Energy type: ", info: filter.energy_type},
+                                        {label: "Energy type: ", info: filter.energy_type.join( ", " )},
                                         {label: "Unit: ", info: filter.unit},
                                         {label: "Category: ", info: filter.category},
                                         {label: "Secondary category: ", info: filter.secondary_category},

--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -168,9 +168,9 @@ function FiltersForm (props) {
                                         </Button>
                                       }>
                                       <div>
-                                        Filter description: &nbsp;
+                                        Usage: &nbsp;
                                         {filter.description}<br/>
-                                        Source: &nbsp;
+                                        Data Source: &nbsp;
                                         <a href={filter.source_url} target="_blank"> {filter.source_url} </a>
                                       </div>
                                     </DropdownWide>

--- a/app/assets/scripts/components/explore/form/filters-form.js
+++ b/app/assets/scripts/components/explore/form/filters-form.js
@@ -30,39 +30,6 @@ background: rgba(0,0,0,0.8);
 color: white;
 `;
 
-/* Filters info table
- * @param filter_data is an array of shape
- *  [
- *    {label: String, info: String},
- *    ...
- *  ]
- */
-function FilterInfoTable (props) {
-  const { filter_data } = props;
-  return (
-    <table style={{"border": "1px solid", "margin": "auto"}}>
-      <tbody>
-          <tr key={filter_data.filter_title+"-label"}>
-            <td style={{"padding": "5px", "border": "1px solid"}}>Filter title</td>
-            <td style={{"padding": "5px", "border": "1px solid"}}>{filter_data.filter_title}</td>
-          </tr>
-          <tr key={filter_data.filter_title+"-description"}>
-            <td style={{"padding": "5px", "border": "1px solid"}}>Filter description</td>
-            <td style={{"padding": "5px", "border": "1px solid"}}>{filter_data.filter_description}</td>
-          </tr>
-          <tr key={filter_data.filter_title+"-source_url"}>
-            <td style={{"padding": "5px", "border": "1px solid"}}>Data source</td>
-            <td style={{"padding": "5px", "border": "1px solid"}}><a href={filter_data.filter_source} target="_blank"> {filter_data.filter_source} </a></td>
-          </tr>
-      </tbody>
-    </table>
-  );
-}
-
-FilterInfoTable.propTypes = {
-  filter_data: T.array,
-};
-
 /* Filters form
  * @param outputFilters is an array of shape
  *  [
@@ -200,11 +167,12 @@ function FiltersForm (props) {
                                           Info
                                         </Button>
                                       }>
-                                      <FilterInfoTable filter_data={{
-                                        filter_title: filter.title, 
-                                        filter_description: filter.description,
-                                        filter_source: filter.source_url, 
-                                      }}/>
+                                      <div>
+                                        Filter description: &nbsp;
+                                        {filter.description}<br/>
+                                        Source: &nbsp;
+                                        <a href={filter.source_url} target="_blank"> {filter.source_url} </a>
+                                      </div>
                                     </DropdownWide>
                                   )}
 


### PR DESCRIPTION
# Adresses ticket https://github.com/orgs/kartoza/projects/20 

Previously the info button was only showing the filter's description and when clicked shows nothing:
![image](https://user-images.githubusercontent.com/29183781/206230809-48ebf88d-e853-4773-8b7c-d5d25e8c98a1.png)

This PR keeps the tool tip and adds a drop down to read informations about the filter like in the screenshot below:
![image](https://user-images.githubusercontent.com/29183781/206229778-48aee951-cac4-44a5-8298-1bf9f38d37f1.png)
![image](https://user-images.githubusercontent.com/29183781/206230012-7f564ab6-9fd5-42a8-b5a3-185f74def0c8.png)
