### PR TITLE
Clip regions

### DIFF
--- a/app/assets/scripts/components/common/mb-map/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map/mb-map.js
@@ -302,8 +302,10 @@ const addInputLayersToMap = (map, layers, selectedArea, resource) => {
   // Off-shore mask flag
   const offshoreWindMask = resource === RESOURCES.OFFSHORE ? '&offshore=true' : '';
 
+  console.log( "addInputLayersToMap", selectedArea );
+
   // If area of country type, prepare country & resource path string to add to URL
-  const countryResourcePath = selectedArea.type === 'country' ? `/${selectedArea.id}/${apiResourceNameMap[resource]}` : '';
+  const countryResourcePath = `/${selectedArea.id}/${apiResourceNameMap[resource]}`;
 
   layers.forEach((layer) => {
     const { id: layerId, tiles: layerTiles, symbol, type: layerType } = layer;

--- a/app/assets/scripts/components/common/mb-map/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map/mb-map.js
@@ -302,8 +302,6 @@ const addInputLayersToMap = (map, layers, selectedArea, resource) => {
   // Off-shore mask flag
   const offshoreWindMask = resource === RESOURCES.OFFSHORE ? '&offshore=true' : '';
 
-  console.log( "addInputLayersToMap", selectedArea );
-
   // If area of country type, prepare country & resource path string to add to URL
   const countryResourcePath = `/${selectedArea.id}/${apiResourceNameMap[resource]}`;
 

--- a/app/assets/scripts/context/explore-context.js
+++ b/app/assets/scripts/context/explore-context.js
@@ -325,10 +325,10 @@ export function ExploreProvider (props) {
       .join('&');
 
     // If area of country type, prepare country path string to add to URL
-    const countryPath = selectedArea.type === 'country' ? `${selectedArea.id}/` : '';
+    const countryPath = `${selectedArea.id}/`;
 
     // if area of country type, prepare resource path string to add to URL
-    const resourcePath = selectedArea.type === 'country' ? `${apiResourceNameMap[selectedResource]}/` : '';
+    const resourcePath = `${apiResourceNameMap[selectedResource]}/`;
 
     // Off-shore mask flag
     const offshoreWindMask = selectedResource === RESOURCES.OFFSHORE ? '&offshore=true' : '';

--- a/app/assets/scripts/context/reducers/zones.js
+++ b/app/assets/scripts/context/reducers/zones.js
@@ -130,7 +130,7 @@ export async function fetchZones (
     }
 
     // If area of country type, prepare country & resource path string to add to URL
-    const countryResourcePath = selectedArea.type === 'country' ? `/${selectedArea.id}/${apiResourceNameMap[selectedResource]}` : '';
+    const countryResourcePath = `/${selectedArea.id}/${apiResourceNameMap[selectedResource]}`;
 
     // Fetch Lcoe for each sub-area
     const zoneUpdateInterval = setInterval(() => {


### PR DESCRIPTION
Addresses https://github.com/kartoza/rezoning-2-project/issues/7
This PR makes sure that the frontend is using the region code when fetching layer data from the backend:

The regions are now properly clipped  
![clip-regions](https://user-images.githubusercontent.com/29183781/211042819-51c05b37-1a5e-4686-adaf-da8ea7e2da31.png)

Related PR: https://github.com/worldbank/WB-rezoning-explorer-api/pull/4