### PR TITLE
Zone color visualization update

### DIFF
--- a/app/assets/scripts/components/common/color-scale.js
+++ b/app/assets/scripts/components/common/color-scale.js
@@ -28,7 +28,7 @@ const Wrapper = styled.div`
   padding: 0.5rem 0;
 `;
 
-function ColorScale ({ min, max, steps, heading, colorFunction }) {
+function ColorScale ({ minLabel, maxLabel, steps, heading, colorFunction }) {
   return (
     <Wrapper>
       <Subheading size='small'>{heading}</Subheading>
@@ -48,16 +48,16 @@ function ColorScale ({ min, max, steps, heading, colorFunction }) {
         }
       </Scale>
       <Labels>
-        <Subheading>{min}</Subheading>
-        <Subheading>{max}</Subheading>
+        <Subheading>{minLabel}</Subheading>
+        <Subheading>{maxLabel}</Subheading>
       </Labels>
     </Wrapper>
   );
 }
 
 ColorScale.propTypes = {
-  min: T.oneOfType([T.number, T.string]),
-  max: T.oneOfType([T.number, T.string]),
+  minLabel: T.oneOfType([T.number, T.string]),
+  maxLabel: T.oneOfType([T.number, T.string]),
   steps: T.number,
   heading: T.string,
   colorFunction: T.func

--- a/app/assets/scripts/components/common/mb-map/map-legend.js
+++ b/app/assets/scripts/components/common/mb-map/map-legend.js
@@ -300,7 +300,7 @@ FilteredAreaLegendItem.propTypes = {
   mapLayers: T.array
 };
 
-function ZoneScoreLegendItem({ mapLayers, wide }) {
+function ZoneScoreLegendItem({ mapLayers, wide, minLabel, maxLabel }) {
   const zoneScoreVisible = mapLayers.filter(
     (layer) =>
       layer.id === ZONES_BOUNDARIES_LAYER_ID &&
@@ -330,15 +330,17 @@ function ZoneScoreLegendItem({ mapLayers, wide }) {
           </LegendLabelsStyled>
         )}
       </LegendLinear>
-      <InputLabel>0</InputLabel>
-      <InputLabel align='right'>1</InputLabel>
+      <InputLabel>{minLabel}</InputLabel>
+      <InputLabel align='right'>{maxLabel}</InputLabel>
     </LegendItemWrapper>
   );
 }
 
 ZoneScoreLegendItem.propTypes = {
   mapLayers: T.array,
-  wide: T.bool
+  wide: T.bool,
+  minLabel: T.oneOfType([T.number, T.string]),
+  maxLabel: T.oneOfType([T.number, T.string]),
 };
 
 export default function MapLegend({
@@ -353,6 +355,15 @@ export default function MapLegend({
   const landCoverVisible =
     mapLayers.filter(({ id, visible }) => id === 'land-cover' && visible)
       .length > 0;
+  let minZoneScore = 0, maxZoneScore = 1;
+  if ( Array.isArray( currentZones?.data ) )
+  {
+    minZoneScore = Math.min( ...currentZones.data.map( z => get(z, 'properties.summary.zone_score', 1.0) ) );
+    maxZoneScore = Math.max( ...currentZones.data.map( z => get(z, 'properties.summary.zone_score', 0.0) ) );
+    minZoneScore = Math.floor( minZoneScore * 1000.0 ) / 1000.0;
+    maxZoneScore = Math.ceil( maxZoneScore * 1000.0 ) / 1000.0;
+  }
+    
   return (
     <MapLegendSelf wide={landCoverVisible} id='map-legend' isExpanded={showMapLegend}>
       <LegendFoldTrigger
@@ -400,7 +411,7 @@ export default function MapLegend({
         filtersLists={filtersLists}
         currentZones={currentZones}
       />
-      <ZoneScoreLegendItem mapLayers={mapLayers} wide={landCoverVisible} />
+      <ZoneScoreLegendItem mapLayers={mapLayers} wide={landCoverVisible} minLabel={minZoneScore} maxLabel={maxZoneScore} />
     </MapLegendSelf>
   );
 }

--- a/app/assets/scripts/components/explore/explore-zones.js
+++ b/app/assets/scripts/components/explore/explore-zones.js
@@ -166,9 +166,14 @@ function ExploreZones (props) {
 
   const [sortId, setSortId] = useState('lcoe');
 
+  let minZoneScore = Math.min( ...currentZones.map( z => get(z, 'properties.summary.zone_score', 1.0) ) );
+  let maxZoneScore = Math.max( ...currentZones.map( z => get(z, 'properties.summary.zone_score', 0.0) ) );
+  minZoneScore = Math.floor( minZoneScore * 1000.0 ) / 1000.0;
+  maxZoneScore = Math.ceil( maxZoneScore * 1000.0 ) / 1000.0;
+
   return (
     <ZonesWrapper active={active}>
-      <ColorScale steps={10} heading='Weighted Zone Score' min={0} max={1} colorFunction={zoneScoreColor} />
+      <ColorScale steps={10} heading='Weighted Zone Score' minLabel={minZoneScore} maxLabel={maxZoneScore} colorFunction={zoneScoreColor} />
       {focusZone ? (
         <ZonesHeader>
           <Button onClick={() => setFocusZone(null)} size='small' useIcon={['chevron-left--small', 'before']}>

--- a/app/assets/scripts/context/reducers/zones.js
+++ b/app/assets/scripts/context/reducers/zones.js
@@ -151,11 +151,13 @@ export async function fetchZones (
       ...zones.map((z) => get(z, 'properties.summary.zone_score', 0))
     );
 
-    const data = zones.map((z) => {
+    zones.sort( ( z1, z2 ) => get(z1, 'properties.summary.zone_score', 0.5) - get(z2, 'properties.summary.zone_score', 0.5) );
+
+    const data = zones.map((z, index) => {
       if (!get(z, 'properties.summary.zone_score')) return z;
 
       const zoneScore = z.properties.summary.zone_score / maxScore;
-      const color = zoneScoreColor(zoneScore);
+      const color = zoneScoreColor(index, 0, zones.length - 1);
       return {
         ...z,
         properties: {

--- a/app/assets/scripts/styles/zoneScoreColors.js
+++ b/app/assets/scripts/styles/zoneScoreColors.js
@@ -1,20 +1,15 @@
-export const COLOR_SCALE = [
-  '#c2ffe2',
-  '#9febe6',
-  '#7bd7eb',
-  '#58c4ef',
-  '#35b0f3',
-  '#1f94e3',
-  '#176fc0',
-  '#104a9d',
-  '#08257a',
-  '#000057'
-];
+import chroma from "chroma-js";
+
+const chromaScale = chroma.scale(['#c2ffe2', '#000057']).domain([0.0, 1.0]);
 
 const MAX_SCORE = 1;
 
-export default function zoneScoreColor (score) {
-  const steps = COLOR_SCALE.length;
-  const index = Math.ceil((score / MAX_SCORE) * steps) - 1;
-  return COLOR_SCALE[index];
+export default function zoneScoreColor (score, minScore = 0, maxScore = MAX_SCORE) {
+  if (minScore >= maxScore) {
+    minScore = 0;
+    maxScore = MAX_SCORE;
+  }
+  return chromaScale( (score - minScore) / (maxScore - minScore) ).toString();
 }
+
+export const COLOR_SCALE = [...Array(10).keys()].map( (i) => chromaScale( i * 1.0 / 9.0 ).toString() );

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "@visx/legend": "^1.3.0",
     "@visx/scale": "^1.3.0",
     "blob-stream": "^0.1.3",
+    "brfs": "^2.0.2",
+    "chroma-js": "^2.4.2",
     "clipboard": "^2.0.6",
     "colormap": "^2.3.1",
     "d3": "^6.2.0",


### PR DESCRIPTION
Adresses: https://github.com/kartoza/rezoning-2-project/issues/21
The coloring of zone scores was previously done with just 10 colors with a domain from 0 to 1. In situations where the scores of different areas are close together in a range from 0.95 to 1 for example, all the zones will be painted with the same color in both the map and the histogram.
This PR fixes this issue by making sure we provide each zone with a different color and scaling the domain to [minZoneScore, maxZoneScore] range so that the lowest score area will appear with much different color than the maximum score area.
How this looks on the map:
![zone-score-viz](https://user-images.githubusercontent.com/29183781/211048562-6a565dc4-76b6-4602-81d1-1da4270331bd.png)

