### PR TITLE
Fix zone size in the square grid functions

### DIFF
--- a/app/assets/scripts/context/reducers/zones.js
+++ b/app/assets/scripts/context/reducers/zones.js
@@ -77,7 +77,7 @@ export async function fetchZones (
 
     if (selectedResource === 'Off-Shore Wind') {
       // if offshore wind, we are already in grid and bounds are eez bounds
-      features = squareGrid(selectedArea.bounds, selectedZoneType.size, {
+      features = squareGrid(selectedArea.bounds, Math.sqrt(parseInt(selectedZoneType.size)), {
         units: 'kilometers',
         mask: {
           type: 'FeatureCollection',
@@ -97,7 +97,7 @@ export async function fetchZones (
           zonesTopoJSON.objects[areaId].geometries
         );
 
-        const areaGrid = squareGrid(selectedArea.bounds, selectedZoneType.size, {
+        const areaGrid = squareGrid(selectedArea.bounds, Math.sqrt(parseInt(selectedZoneType.size)), {
           mask: areaLimits,
           units: 'kilometers'
         });


### PR DESCRIPTION
Cellside has been used incorrectly in previous calculations, where it was considered to be 25km2 or 50km2. This led to inaccurate results, as 'cellside' does not represent the area size.

After :
![image](https://github.com/worldbank/WB-rezoning-explorer/assets/1979569/17bf1793-5698-43a0-a11c-57bf1f7500b0)
