### PR TITLE
Fixes contextual layer

### DIFF
--- a/app/assets/scripts/components/explore/prime-panel.js
+++ b/app/assets/scripts/components/explore/prime-panel.js
@@ -121,6 +121,7 @@ function ExpMapPrimePanel (props) {
 
   const [showRasterPanel, setShowRasterPanel] = useState(false);
   const [showSubmitIssuePanel, setShowSubmitIssuePanel] = useState(false);
+  const [prevSelectedResource,setPrevSelectedResource] = useState(selectedResource)
 
   const onAreaEdit = () => {
     setShowSelectAreaModal(true);
@@ -139,6 +140,7 @@ function ExpMapPrimePanel (props) {
   };
 
   React.useEffect(() => {
+    setPrevSelectedResource(selectedResource)
     if (!(Object.keys(currentZones?.data).length === 0)) {
       setShowRasterPanel(true);
       
@@ -154,7 +156,13 @@ function ExpMapPrimePanel (props) {
       })
       );
     }
-  }, [currentZones?.data]);
+    else {
+      setShowRasterPanel(false);
+    }
+    if(selectedResource != prevSelectedResource ){
+      setShowRasterPanel(false);
+    }  
+  }, [currentZones?.data,selectedResource]);
 
   React.useEffect(() => {
     const availableZone = availableZoneTypes.filter(


### PR DESCRIPTION
This is to fix : #74

proposed solution: When parameters are changed, contextual layers pop up should close and open when results are generated

before : 
<img width="1604" alt="Screenshot 2023-05-26 at 5 47 42 PM" src="https://github.com/worldbank/WB-rezoning-explorer/assets/11027786/d77b39a3-9571-4af2-bdbc-0499e4c3099e">

after:
<img width="1605" alt="Screenshot 2023-05-26 at 5 49 15 PM" src="https://github.com/worldbank/WB-rezoning-explorer/assets/11027786/719ac930-50a4-4013-b88e-213b03c482ec">

