### PR TITLE
Fixes for histogram window

### DIFF
--- a/app/assets/scripts/components/common/info-button.js
+++ b/app/assets/scripts/components/common/info-button.js
@@ -8,6 +8,9 @@ const StyledTooltip = styled(ReactTooltip)`
   /* Z index set to 1000 to go over shadow scroll bar
    * which has z-index 1000 */
   z-index: 1001;
+  &.tooltip {
+    z-index:9999
+  } 
 `;
 
 function InfoButton (props) {
@@ -25,7 +28,7 @@ function InfoButton (props) {
         {props.children}
       </Button>
       {info &&
-        <StyledTooltip width={width} id={id} place='bottom' effect='solid'>
+        <StyledTooltip className='tooltip' width={width} id={id} place='bottom' effect='solid' >
           {info}
         </StyledTooltip>}
     </>

--- a/app/assets/scripts/components/explore/explore-carto.js
+++ b/app/assets/scripts/components/explore/explore-carto.js
@@ -1,10 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import Histogram from '../common/histogram';
 import { themeVal } from '../../styles/utils/general';
 import MbMap from '../common/mb-map/mb-map';
 import MapContext from '../../context/map-context';
+import ExploreContext from '../../context/explore-context';
 // import ExploreContext from '../../context/explore-context';
 
 const ExploreCarto = styled.section`
@@ -23,6 +24,20 @@ function Carto (props) {
     zoneData
   } = props;
   const { setFocusZone, setHoveredFeature, hoveredFeature } = useContext(MapContext);
+  const { selectedResource } = useContext(ExploreContext);
+  const [prevSelectedResource,setPrevSelectedResource] = useState(selectedResource)
+  const[isHistogramVisible,setIsHistogramVisible] = useState(true);
+
+  useEffect(()=>{
+    setPrevSelectedResource(selectedResource)
+    if(selectedResource != prevSelectedResource){
+      setIsHistogramVisible(false)
+    }
+    else{
+      setIsHistogramVisible(true)
+    }
+  },[selectedResource])
+
   /*
    * Disable filtering temporarily
   const {
@@ -36,7 +51,7 @@ function Carto (props) {
       <MbMap
         triggerResize={triggerResize}
       />
-      { zoneData && (
+      { zoneData && isHistogramVisible && (
         <Histogram
           yProp='lcoe'
           xProp={['generation_potential', 'lcoe']}

--- a/app/assets/scripts/components/explore/explore-carto.js
+++ b/app/assets/scripts/components/explore/explore-carto.js
@@ -26,7 +26,7 @@ function Carto (props) {
   const { setFocusZone, setHoveredFeature, hoveredFeature } = useContext(MapContext);
   const { selectedResource } = useContext(ExploreContext);
   const [prevSelectedResource,setPrevSelectedResource] = useState(selectedResource)
-  const[isHistogramVisible,setIsHistogramVisible] = useState(true);
+  const [isHistogramVisible,setIsHistogramVisible] = useState(true);
 
   useEffect(()=>{
     setPrevSelectedResource(selectedResource)


### PR DESCRIPTION
Task : #74

This PR is for Close histogram window when user change the resources 

before:
<img width="1668" alt="Screenshot 2023-06-08 at 2 05 45 PM" src="https://github.com/worldbank/WB-rezoning-explorer/assets/11027786/a0d5cf88-622d-43bc-94bd-f7270f351be1">

after:

<img width="1604" alt="Screenshot 2023-06-08 at 2 06 14 PM" src="https://github.com/worldbank/WB-rezoning-explorer/assets/11027786/73556e47-67a8-4ba5-84b4-507594034ce2">
