### PR TITLE
Round down min, round up max

### DIFF
--- a/app/assets/scripts/context/form-context.js
+++ b/app/assets/scripts/context/form-context.js
@@ -84,7 +84,6 @@ export function FormProvider (props) {
       setInputTouched(false);
     }
   }, [currentZones]);
-
   return (
     <>
       <FormContext.Provider

--- a/app/assets/scripts/context/qs-state-schema.js
+++ b/app/assets/scripts/context/qs-state-schema.js
@@ -1,4 +1,4 @@
-import { round } from '../utils/format';
+import {round, roundDown} from '../utils/format';
 import get from 'lodash.get';
 import inRange from 'lodash.inrange';
 import intersection from 'lodash.intersection';
@@ -59,12 +59,15 @@ export const initByType = (obj, ranges, resource) => {
   const apiRange = ranges[obj.layer];
   const { input, options } = obj;
 
-  const range = setRangeByUnit(
-    (apiRange && [round(apiRange.min), round(apiRange.max)]) ||
+  let range = setRangeByUnit(
+    (apiRange && [roundDown(apiRange.min), round(apiRange.max)]) ||
       obj.input.range ||
       DEFAULT_RANGE,
     obj.unit
-  ).map((v) => round(v));
+  );
+  if (range.length > 1) {
+    range = [roundDown(range[0]), round(range[1])];
+  }
 
   switch (input.type) {
     case SLIDER:

--- a/app/assets/scripts/utils/format.js
+++ b/app/assets/scripts/utils/format.js
@@ -10,6 +10,10 @@ export function round (value, decimals = 2) {
   return Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals);
 }
 
+export function roundDown (value, decimals = 2) {
+  return Math.floor(value * Math.pow(10, decimals)) / Math.pow(10, decimals);
+}
+
 export function truncateDecimals (number, digits = 2) {
   const multiplier = Math.pow(10, digits);
   const adjustedNum = number * multiplier;


### PR DESCRIPTION
This PR fixes a problem where some countries don't show any suitable areas. The problem happened because we rounded up some small numbers.

Here's an example: for Fiji, the server gives us these numbers:
```

grid: {
     min: 65535,
     max: 492521.34375
},
```

These numbers are in meters. We change them to kilometers by dividing by 1000, which gives us:
```
grid: {
     min: 65.535,
     max: 492.521
},
```
However, previously, both min and max values were rounded up. Consequently, the range in the slider would become:

![image](https://github.com/worldbank/WB-rezoning-explorer/assets/1979569/a51df5f8-49e6-4063-a0e9-8399f600f660)

When we request the zone data from backend, we used a range from 65.54 to 492.521. Because we rounded up, we missed the areas that were 65.535. So, sometimes we got no results.

This PR fixes this by changing how we round numbers, making sure we include all the right areas.

cc @ClaraIV 