### PR TITLE
Fix CORS redirect issue with layers in prod

### DIFF
--- a/app/assets/scripts/context/reducers/layers.js
+++ b/app/assets/scripts/context/reducers/layers.js
@@ -15,7 +15,7 @@ export async function fetchInputLayers (dispatch) {
   dispatch({ type: 'REQUEST_LAYERS' });
   try {
     const layers = (
-      await fetchJSON(`${apiEndpoint}/layers`)
+      await fetchJSON(`${apiEndpoint}/layers/`)
     ).body;
 
     const layerList = Object.keys(layers).map(id => ({


### PR DESCRIPTION
* Redirect from /layers to /layers/ was absolute, and on prod, the API is behind cloudfront, so this redirected to the api endpoint instead, which doesn't have cors enabled.